### PR TITLE
COMP: Fix invalid constexpr for compilation errors with the clang com…

### DIFF
--- a/color.hpp
+++ b/color.hpp
@@ -66,13 +66,13 @@ struct Color {
         return { r/a, g/a, b/a, a };
     }
 
-    constexpr float distance(Color const& other) const {
+    float distance(Color const& other) const {
         auto rmean = (other.r + r)/2;
         auto diff = other - (*this);
         return std::sqrt((2.0f + rmean)*diff.r*diff.r + 4.0f*diff.g*diff.g + (3.0f - rmean)*diff.b*diff.b);
     }
 
-    constexpr float hue_distance(Color const& other) const {
+    float hue_distance(Color const& other) const {
         return std::abs(other.hue() - hue());
     }
 
@@ -88,7 +88,7 @@ struct Color {
         return (premultiplied() + other.premultiplied()*(1.0f - a)).unpremultiplied();
     }
 
-    constexpr Color32 color32(std::uint8_t white = 255, std::uint8_t opaque = 255) const {
+    Color32 color32(std::uint8_t white = 255, std::uint8_t opaque = 255) const {
         using utils::clamp;
         return {
             std::uint8_t(std::lround(clamp(r, 0.0f, 1.0f)*white)),


### PR DESCRIPTION
…piler

plot/color.hpp:69:21: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
    constexpr float distance(Color const& other) const {

plot/color.hpp:75:21: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
    constexpr float hue_distance(Color const& other) const {

color.hpp:69:21: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
plot/color.hpp:69:21: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
    constexpr float distance(Color const& other) const {

These compilation errors are fixed by removing the
constexpr designation.