### PR TITLE
ENH: Provide ignores for disregarding IDE temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@
 
 # Build dir
 build
+
+# ide files
+cmake-build-*/
+.idea


### PR DESCRIPTION
Ignore the .idea and cmake-build-debug directories
when using the CLion IDE.