### PR TITLE
COMP: Remove shadow variable warnings

### DIFF
--- a/braille.hpp
+++ b/braille.hpp
@@ -59,17 +59,17 @@ namespace detail { namespace braille
     struct block_t {
         constexpr block_t() = default;
 
-        constexpr block_t(Color color, bool px00, bool px01, bool px02, bool px03,
+        constexpr block_t(Color icolor, bool px00, bool px01, bool px02, bool px03,
                                        bool px10, bool px11, bool px12, bool px13)
-            : color(color),
+            : color(icolor),
               pixels(pixel_codes[0][0]*px00 | pixel_codes[0][1]*px01 |
                      pixel_codes[0][2]*px02 | pixel_codes[0][3]*px03 |
                      pixel_codes[1][0]*px10 | pixel_codes[1][1]*px11 |
                      pixel_codes[1][2]*px12 | pixel_codes[1][3]*px13)
             {}
 
-        constexpr block_t(Color color, std::uint8_t pixels = 0)
-            : color(color), pixels(pixels)
+        constexpr block_t(Color icolor, std::uint8_t ipixels = 0)
+            : color(icolor), pixels(ipixels)
             {}
 
         block_t& clear() {
@@ -203,8 +203,8 @@ namespace detail { namespace braille
         template<typename>
         friend std::ostream& operator<<(std::ostream&, line_t const&);
 
-        line_t(BrailleCanvas const* canvas, image_t::const_iterator it)
-            : canvas(canvas), it(it)
+        line_t(BrailleCanvas const* icanvas, image_t::const_iterator iit)
+            : canvas(icanvas), it(iit)
             {}
 
         line_t next() const;
@@ -238,16 +238,16 @@ public:
 
     BrailleCanvas() = default;
 
-    BrailleCanvas(Size char_size, TerminalInfo term = TerminalInfo())
+    BrailleCanvas(Size char_size, TerminalInfo iterm = TerminalInfo())
         : lines(char_size.y), cols(char_size.x), blocks(char_size),
-          background(term.background_color), term(term)
+          background(iterm.background_color), term(iterm)
     {
         available_layers.emplace_front(char_size);
     }
 
-    BrailleCanvas(Color background, Size char_size, TerminalInfo term = TerminalInfo())
+    BrailleCanvas(Color ibackground, Size char_size, TerminalInfo iterm = TerminalInfo())
         : lines(char_size.y), cols(char_size.x), blocks(char_size),
-          background(background), term(term)
+          background(ibackground), term(iterm)
     {
         available_layers.emplace_front(char_size);
     }
@@ -317,8 +317,8 @@ public:
         return *this;
     }
 
-    BrailleCanvas& clear(Color background) {
-        this->background = background;
+    BrailleCanvas& clear(Color ibackground) {
+        this->background = ibackground;
         return clear();
     }
 

--- a/color.hpp
+++ b/color.hpp
@@ -50,8 +50,8 @@ constexpr Color operator/(float const& lhs, Color const& rhs);
 struct Color {
     constexpr Color() : r(0), g(0), b(0), a(0) {}
 
-    constexpr Color(float r, float g, float b, float a = 1.0f)
-        : r(r), g(g), b(b), a(a)
+    constexpr Color(float ir, float ig, float ib, float ia = 1.0f)
+        : r(ir), g(ig), b(ib), a(ia)
         {}
 
     constexpr Color(Color32 c, std::uint8_t white = 255, std::uint8_t opaque = 255)

--- a/examples/animation.cpp
+++ b/examples/animation.cpp
@@ -55,18 +55,18 @@ int main() {
 
     float t = 0.0f;
 
-    auto sin = [N,f](float t, float x) {
-        return std::sin(2*3.141592f*f*(t + x/N));
+    auto sin = [N,f](float tt, float x) {
+        return std::sin(2*3.141592f*f*(tt + x/N));
     };
 
-    auto cos = [N,f](float t, float x) {
-        return std::cos(2*3.141592f*f*(t + x/N));
+    auto cos = [N,f](float tt, float x) {
+        return std::cos(2*3.141592f*f*(tt + x/N));
     };
 
-    auto stroke_fn = [y0,A](auto const& fn, float t) {
-        return [y0,A,fn,t](float x) {
-            Coord base = y0 + A - std::lround(A*fn(t, x)),
-                  end  = y0 + A - std::lround(A*fn(t, x + 1));
+    auto stroke_fn = [y0,A](auto const& fn, float tt) {
+        return [y0,A,fn,tt](float x) {
+            Coord base = y0 + A - std::lround(A*fn(tt, x)),
+                  end  = y0 + A - std::lround(A*fn(tt, x + 1));
             return (base != end) ? std::make_pair(base, end) : std::make_pair(base, base+1);
         };
     };

--- a/examples/boxes.cpp
+++ b/examples/boxes.cpp
@@ -63,33 +63,32 @@ int main() {
     auto y0 = rect.p1.y, A = size.y/2, N = size.x;
     float f = 2;
 
-    float t = 0.0f;
-
-    auto sin = [N,f](float t, float x) {
-        return std::sin(2*3.141592f*f*(t + x/N));
+    auto sin = [N,f](float tt, float x) {
+        return std::sin(2*3.141592f*f*(tt + x/N));
     };
 
-    auto cos = [N,f](float t, float x) {
-        return std::cos(2*3.141592f*f*(t + x/N));
+    auto cos = [N,f](float tt, float x) {
+        return std::cos(2*3.141592f*f*(tt + x/N));
     };
 
-    auto sin2 = [sin](float t, float x) {
-        auto val = sin(t, x);
+    auto sin2 = [sin](float tt, float x) {
+        auto val = sin(tt, x);
         return val*val;
     };
 
-    auto sincos = [sin,cos](float t, float x) {
-        return sin(t, x) * cos(t, x);
+    auto sincos = [sin,cos](float tt, float x) {
+        return sin(tt, x) * cos(tt, x);
     };
 
-    auto stroke_fn = [y0,A](auto const& fn, float t) {
-        return [y0,A,fn,t](float x) {
-            Coord base = y0 + A - std::lround(A*fn(t, x)),
-                  end  = y0 + A - std::lround(A*fn(t, x + 1));
+    auto stroke_fn = [y0,A](auto const& fn, float tt) {
+        return [y0,A,fn,tt](float x) {
+            Coord base = y0 + A - std::lround(A*fn(tt, x)),
+                  end  = y0 + A - std::lround(A*fn(tt, x + 1));
             return (base != end) ? std::make_pair(base, end) : std::make_pair(base, base+1);
         };
     };
 
+    float t = 0.0f;
     while (true) {
         waves.clear()
              .stroke({ 0.2f, 0.2f, 1.0f }, rect, stroke_fn(sin, t))
@@ -120,9 +119,9 @@ int main() {
 
         auto track_length = N/Coord(2*f)/2;
         for (Coord x = 0; x < track_length; ++x) {
-            Pointf pos(sincos(t, N - x), sin2(t, N - x));
+            Pointf npos(sincos(t, N - x), sin2(t, N - x));
             Pointf prev(sincos(t, N - x - 1), sin2(t, N - x - 1));
-            circle.line(term.foreground_color.alpha(float(track_length - x)/track_length), pos, prev);
+            circle.line(term.foreground_color.alpha(float(track_length - x)/track_length), npos, prev);
         }
 
         circle.pop();

--- a/layout.hpp
+++ b/layout.hpp
@@ -83,7 +83,7 @@ namespace detail
     private:
         friend Block;
 
-        block_iterator(Line line) : line(line) {}
+        block_iterator(Line iline) : line(iline) {}
 
         Line line;
     };
@@ -131,8 +131,8 @@ namespace detail
         template<typename, bool>
         friend struct normal_block_ref_traits;
 
-        single_line_adapter(pointer block, bool end = false)
-            : block(block), end(end)
+        single_line_adapter(pointer iblock, bool iend = false)
+            : block(iblock), end(iend)
             {}
 
         pointer block;
@@ -342,9 +342,9 @@ namespace detail
 
         friend std::ostream& operator<< <Block>(std::ostream&, margin_line const&);
 
-        margin_line(Margin<Block> const* margin, std::ptrdiff_t overflow,
-                    block_iterator line, block_iterator end)
-            : margin(margin), overflow(overflow), line(std::move(line)), end(std::move(end))
+        margin_line(Margin<Block> const* imargin, std::ptrdiff_t ioverflow,
+                    block_iterator iline, block_iterator iend)
+            : margin(imargin), overflow(ioverflow), line(std::move(iline)), end(std::move(iend))
             {}
 
         margin_line next() const {
@@ -394,21 +394,21 @@ public:
     using difference_type = typename const_iterator::difference_type;
     using size_type = Size;
 
-    explicit Margin(Block block)
-        : block(std::move(block))
+    explicit Margin(Block iblock)
+        : block(std::move(iblock))
         {}
 
-    explicit Margin(std::size_t margin, Block block)
-        : top(margin), right(margin), bottom(margin), left(margin), block(std::move(block))
+    explicit Margin(std::size_t imargin, Block iblock)
+        : top(imargin), right(imargin), bottom(imargin), left(imargin), block(std::move(iblock))
         {}
 
-    explicit Margin(std::size_t v, std::size_t h, Block block)
-        : top(v), right(h), bottom(v), left(h), block(std::move(block))
+    explicit Margin(std::size_t iv, std::size_t ih, Block iblock)
+        : top(iv), right(ih), bottom(iv), left(ih), block(std::move(iblock))
         {}
 
-    explicit Margin(std::size_t top, std::size_t right, std::size_t bottom,
-                    std::size_t left, Block block)
-        : top(top), right(right), bottom(bottom), left(left), block(std::move(block))
+    explicit Margin(std::size_t itop, std::size_t iright, std::size_t ibottom,
+                    std::size_t ileft, Block iblock)
+        : top(itop), right(iright), bottom(ibottom), left(ileft), block(std::move(iblock))
         {}
 
     Size size() const {
@@ -488,9 +488,9 @@ namespace detail
 
         friend std::ostream& operator<< <Block>(std::ostream&, frame_line const&);
 
-        frame_line(Frame<Block> const* frame, std::ptrdiff_t overflow,
-                   block_iterator line, block_iterator end)
-            : frame(frame), overflow(overflow), line(std::move(line)), end(std::move(end))
+        frame_line(Frame<Block> const* iframe, std::ptrdiff_t ioverflow,
+                   block_iterator iline, block_iterator iend)
+            : frame(iframe), overflow(ioverflow), line(std::move(iline)), end(std::move(iend))
             {}
 
         frame_line next() const {
@@ -522,28 +522,28 @@ public:
     using difference_type = typename const_iterator::difference_type;
     using size_type = Size;
 
-    explicit Frame(Block block, TerminalInfo term = TerminalInfo())
-        : block(std::move(block)), term(term)
+    explicit Frame(Block iblock, TerminalInfo iterm = TerminalInfo())
+        : block(std::move(iblock)), term(iterm)
         {}
 
-    explicit Frame(Border border, Block block, TerminalInfo term = TerminalInfo())
-        : border(border), block(std::move(block)), term(term)
+    explicit Frame(Border iborder, Block iblock, TerminalInfo iterm = TerminalInfo())
+        : border(iborder), block(std::move(iblock)), term(iterm)
         {}
 
-    explicit Frame(string_view label, Block block, TerminalInfo term = TerminalInfo())
-        : label(label), block(std::move(block)), term(term)
+    explicit Frame(string_view ilabel, Block iblock, TerminalInfo iterm = TerminalInfo())
+        : label(ilabel), block(std::move(iblock)), term(iterm)
         {}
 
-    explicit Frame(string_view label, Align align, Block block, TerminalInfo term = TerminalInfo())
-        : label(label), align(align), block(std::move(block)), term(term)
+    explicit Frame(string_view ilabel, Align ialign, Block iblock, TerminalInfo iterm = TerminalInfo())
+        : label(ilabel), align(ialign), block(std::move(iblock)), term(iterm)
         {}
 
-    explicit Frame(string_view label, Border border, Block block, TerminalInfo term = TerminalInfo())
-        : label(label), border(border), block(std::move(block)), term(term)
+    explicit Frame(string_view ilabel, Border iborder, Block iblock, TerminalInfo iterm = TerminalInfo())
+        : label(ilabel), border(iborder), block(std::move(iblock)), term(iterm)
         {}
 
-    explicit Frame(string_view label, Align align, Border border, Block block, TerminalInfo term = TerminalInfo())
-        : label(label), align(align), border(border), block(std::move(block)), term(term)
+    explicit Frame(string_view ilabel, Align ialign, Border iborder, Block iblock, TerminalInfo iterm = TerminalInfo())
+        : label(ilabel), align(ialign), border(iborder), block(std::move(iblock)), term(iterm)
         {}
 
     Size size() const {
@@ -715,9 +715,9 @@ namespace detail
 
         friend std::ostream& operator<< <Blocks...>(std::ostream&, vbox_line const&);
 
-        vbox_line(VBox<Blocks...> const* vbox, std::size_t margin,
-                  block_iterators lines, block_iterators ends)
-            : vbox(vbox), margin(margin), lines(std::move(lines)), ends(std::move(ends))
+        vbox_line(VBox<Blocks...> const* ivbox, std::size_t imargin,
+                  block_iterators ilines, block_iterators iends)
+            : vbox(ivbox), margin(imargin), lines(std::move(ilines)), ends(std::move(iends))
             {}
 
         vbox_line next() const {
@@ -807,12 +807,12 @@ public:
     using difference_type = typename const_iterator::difference_type;
     using size_type = Size;
 
-    explicit VBox(Blocks... blocks)
-        : blocks(std::move(blocks)...)
+    explicit VBox(Blocks... iblocks)
+        : blocks(std::move(iblocks)...)
         {}
 
-    explicit VBox(std::size_t margin, Blocks... blocks)
-        : margin(margin), blocks(std::move(blocks)...)
+    explicit VBox(std::size_t imargin, Blocks... iblocks)
+        : margin(imargin), blocks(std::move(iblocks)...)
         {}
 
     Size size() const {
@@ -910,8 +910,8 @@ namespace detail
 
         friend std::ostream& operator<< <Blocks...>(std::ostream&, hbox_line const&);
 
-        hbox_line(HBox<Blocks...> const* hbox, std::size_t margin, block_iterators lines, block_iterators ends)
-            : hbox(hbox), margin(margin), lines(std::move(lines)), ends(std::move(ends))
+        hbox_line(HBox<Blocks...> const* ihbox, std::size_t imargin, block_iterators ilines, block_iterators iends)
+            : hbox(ihbox), margin(imargin), lines(std::move(ilines)), ends(std::move(iends))
             {}
 
         hbox_line next() const {
@@ -990,12 +990,12 @@ public:
     using difference_type = typename const_iterator::difference_type;
     using size_type = Size;
 
-    explicit HBox(Blocks... blocks)
-        : blocks(std::move(blocks)...)
+    explicit HBox(Blocks... iblocks)
+        : blocks(std::move(iblocks)...)
         {}
 
-    explicit HBox(std::size_t margin, Blocks... blocks)
-        : margin(margin), blocks(std::move(blocks)...)
+    explicit HBox(std::size_t imargin, Blocks... iblocks)
+        : margin(imargin), blocks(std::move(iblocks)...)
         {}
 
     Size size() const {

--- a/point.hpp
+++ b/point.hpp
@@ -59,8 +59,8 @@ struct GenericPoint
 
     constexpr GenericPoint() = default;
 
-    constexpr GenericPoint(T x, T y)
-        : x(x), y(y)
+    constexpr GenericPoint(T xx, T yy)
+        : x(xx), y(yy)
         {}
 
     constexpr T distance(GenericPoint const& other) const {

--- a/rect.hpp
+++ b/rect.hpp
@@ -58,8 +58,8 @@ struct GenericRect
 
     constexpr GenericRect() = default;
 
-    constexpr GenericRect(GenericPoint<T> const& p1, GenericPoint<T> const& p2)
-        : p1(p1), p2(p2)
+    constexpr GenericRect(GenericPoint<T> const& ip1, GenericPoint<T> const& ip2)
+        : p1(ip1), p2(ip2)
         {}
 
     constexpr GenericRect(GenericSize<T> const& size)

--- a/terminal.hpp
+++ b/terminal.hpp
@@ -382,19 +382,19 @@ using Terminal = int;
 
 class TerminalInfo {
 public:
-    explicit TerminalInfo(Terminal term = STDOUT_FILENO,
-                          TerminalMode mode = TerminalMode::None,
-                          Color foreground_color = { 0.9f, 0.9f, 0.9f, 1 },
-                          Color background_color = { 0, 0, 0, 1 })
-        : mode(mode), foreground_color(foreground_color), background_color(background_color), term(term)
+    explicit TerminalInfo(Terminal iterm = STDOUT_FILENO,
+                          TerminalMode imode = TerminalMode::None,
+                          Color iforeground_color = { 0.9f, 0.9f, 0.9f, 1 },
+                          Color ibackground_color = { 0, 0, 0, 1 })
+        : mode(imode), foreground_color(iforeground_color), background_color(ibackground_color), term(iterm)
         {}
 
     bool is_terminal() const {
         return isatty(term);
     }
 
-    bool supported(TerminalMode mode) const {
-        return int(mode) <= int(this->mode);
+    bool supported(TerminalMode imode) const {
+        return int(imode) <= int(this->mode);
     }
 
     Size size() const {
@@ -528,8 +528,8 @@ namespace detail
 {
     struct tcsetattr_guard
     {
-        tcsetattr_guard(Terminal term, struct termios old, struct termios new_)
-            : term(term), old(old), new_(new_)
+        tcsetattr_guard(Terminal iterm, struct termios iold, struct termios inew_)
+            : term(iterm), old(iold), new_(inew_)
             {}
 
         ~tcsetattr_guard() {


### PR DESCRIPTION
@fbbdev 
Fabio,

I am going to request this patch set one more time.  I have considered your statements "I have to ask you to remove commit 6973739 from the pull request. All those declarations are intentional, they are mostly used in constructors with an empty body or in places where shadowing is desirable or not an issue anyway. Just build without -Wshadow."

As a 20 year software developer on massively distributed open source community development (see my github page for the many project I contribute to) projects, I think your approach to these compiler warnings is too dismissive.

On numerous occasions I have had seemingly "not an issue anyway" shadow variables be the cause of very difficult to identify bugs that have taken days to track down.  Most of the multi-developer projects that I work on mandate that we leverage the various compiler warning checking mechanisms in order to make the code more robust.  While it is certainly true that shadow variables usually do not cause any issues, avoiding shadow variables when possible provides a more robust solution in a multi-developer environment.  In the rare cases where shadowing would cause issues, having separate names changes a run-time bug (hard to find)  into a compile time bug (easy to fix).  This primarily happens when a developer is refactoring or reusing code several years after it was originally written.


If you still choose to reject this patch set, then I'll not submit it again.

I would like to know if you have a more compelling reason for desiring shadowed variables?

Thank you for your consideration,
Hans