### PR TITLE
COMP: Fix support for gcc 4.9.2

### DIFF
--- a/braille.hpp
+++ b/braille.hpp
@@ -87,7 +87,7 @@ namespace detail { namespace braille
             return *this;
         }
 
-        constexpr block_t over(block_t const& other) const {
+        block_t over(block_t const& other) const {
             auto old = bitcount(other.pixels & ~pixels);
             auto new_ = bitcount(pixels & ~other.pixels);
 
@@ -105,7 +105,7 @@ namespace detail { namespace braille
             return { mixed_color, std::uint8_t(pixels | other.pixels) };
         }
 
-        constexpr block_t paint(block_t const& dst, TerminalOp op) const {
+        block_t paint(block_t const& dst, TerminalOp op) const {
             if (pixels) {
                 switch (op) {
                     case TerminalOp::Over:

--- a/color.hpp
+++ b/color.hpp
@@ -76,7 +76,7 @@ struct Color {
         return std::abs(other.hue() - hue());
     }
 
-    constexpr float hue() const {
+    float hue() const {
         float min = utils::min(r, utils::min(g, b)),
               max = utils::max(r, utils::max(g, b));
         auto h = (max == r) ? (g - b)/(max - min) :

--- a/rect.hpp
+++ b/rect.hpp
@@ -66,7 +66,7 @@ struct GenericRect
         : p1(), p2(size)
         {}
 
-    constexpr GenericRect sorted() const {
+    GenericRect sorted() const {
         auto x = utils::minmax(p1.x, p2.x);
         auto y = utils::minmax(p1.y, p2.y);
         return {


### PR DESCRIPTION
This resolves #5.

To compile on the released version of gcc 4.9.2, multi-line
constexpr are not supported.