### PR TITLE
cmake interface library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(plot INTERFACE)
 target_include_directories(plot INTERFACE include)
 
 option(BUILD_SINGLE_HEADER "Pack all headers into a single header library" OFF)
+option(BUILD_EXAMPLES "Build plot examples" ON)
 
 if(BUILD_SINGLE_HEADER)
     find_package(PythonInterp 3 REQUIRED)
@@ -66,4 +67,7 @@ if(BUILD_SINGLE_HEADER)
         single-header ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/plot.hpp")
 endif()
 
-add_subdirectory(examples)
+
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,31 +29,31 @@ endif()
 
 set(CMAKE_CXX_STANDARD 14)
 
-set(HEADER_FILES
-    include/braille.hpp
-    include/color.hpp
-    include/colors.hpp
-    include/layout.hpp
-    include/plot.hpp
-    include/point.hpp
-    include/real_canvas.hpp
-    include/rect.hpp
-    include/string_view.hpp
-    include/terminal.hpp
-    include/unicode_data.hpp
-    include/unicode_structs.hpp
-    include/unicode.hpp
-    include/utils.hpp)
-
-string(REGEX REPLACE "([^;]+)" "${CMAKE_CURRENT_SOURCE_DIR}/\\1" HEADER_FILES "${HEADER_FILES}")
-
 add_library(plot INTERFACE)
-target_sources(plot INTERFACE ${HEADER_FILES})
+target_include_directories(plot INTERFACE include)
 
 option(BUILD_SINGLE_HEADER "Pack all headers into a single header library" OFF)
 
 if(BUILD_SINGLE_HEADER)
     find_package(PythonInterp 3 REQUIRED)
+
+    set(HEADER_FILES
+        include/braille.hpp
+        include/color.hpp
+        include/colors.hpp
+        include/layout.hpp
+        include/plot.hpp
+        include/point.hpp
+        include/real_canvas.hpp
+        include/rect.hpp
+        include/string_view.hpp
+        include/terminal.hpp
+        include/unicode_data.hpp
+        include/unicode_structs.hpp
+        include/unicode.hpp
+        include/utils.hpp)
+
+    string(REGEX REPLACE "([^;]+)" "${CMAKE_CURRENT_SOURCE_DIR}/\\1" HEADER_FILES "${HEADER_FILES}")
 
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/plot.hpp"
@@ -65,7 +65,5 @@ if(BUILD_SINGLE_HEADER)
     add_custom_target(
         single-header ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/plot.hpp")
 endif()
-
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 add_subdirectory(examples)


### PR DESCRIPTION
This PR "modernizes" the cmake build process:

1. marks the  `plot` header files as interface includes so that cmake targets using `target_link_libraries` automatically pull in the headers (used [here](https://github.com/plusk01/adaptive-gyro-filtering/blob/master/CMakeLists.txt#L32))
2. optionally disables building the applications -- useful when `plot` is included in a superbuild (used [here](https://github.com/plusk01/adaptive-gyro-filtering/blob/master/CMakeLists.txt#L19))

Thanks for the cool plotting library. Would love to see more features be added (e.g., axes, legends, etc.). FYI, I'm using this library [here](https://github.com/plusk01/adaptive-gyro-filtering#c-library) (with eigen).